### PR TITLE
refactor: migrating from gatsby-image to gatsby-plugin-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
     "gatsby": "4.14.1",
-    "gatsby-image": "3.11.0",
     "gatsby-plugin-image": "2.14.1",
     "gatsby-plugin-mdx": "3.14.0",
     "gatsby-plugin-sharp": "4.14.1",

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -2,7 +2,7 @@
 /* eslint jsx-a11y/alt-text: 0 */
 
 import React from 'react';
-import Image from 'gatsby-image';
+import { GatsbyImage } from 'gatsby-plugin-image';
 
 interface ImgProps {
   image: {
@@ -23,7 +23,7 @@ const Img = ({ image, ...rest }: ImgProps) => {
   return image.extension === 'gif' ? (
     <img src={image.publicURL} {...rest} />
   ) : (
-    <Image fluid={image.childImageSharp.fluid} {...rest} />
+    <GatsbyImage fluid={image.childImageSharp.gatsbyImageData} {...rest} />
   );
 };
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -88,16 +88,12 @@ export const query = graphql`
   query {
     whitewater: file(relativePath: { eq: "whitewater.jpg" }) {
       childImageSharp {
-        fluid(maxWidth: 900) {
-          ...GatsbyImageSharpFluid
-        }
+        gatsbyImageData(width: 900)
       }
     }
     family: file(relativePath: { eq: "family.jpg" }) {
       childImageSharp {
-        fluid(maxWidth: 1200) {
-          ...GatsbyImageSharpFluid
-        }
+        gatsbyImageData(width: 1200)
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,7 +2245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.16.7
   resolution: "@babel/runtime@npm:7.16.7"
   dependencies:
@@ -10956,17 +10956,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-image@npm:3.11.0":
-  version: 3.11.0
-  resolution: "gatsby-image@npm:3.11.0"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    object-fit-images: ^3.2.4
-    prop-types: ^15.7.2
-  checksum: da7e8d6fcde678969f4fdc22b2eda1235525ebf848bf1c04fc618920356ea0d8a55bec8a552f01cd7d7c7b3313c1af08dbd2efed198bc87ca4c9831518db4356
-  languageName: node
-  linkType: hard
-
 "gatsby-legacy-polyfills@npm:^2.14.0":
   version: 2.14.0
   resolution: "gatsby-legacy-polyfills@npm:2.14.0"
@@ -14398,7 +14387,6 @@ __metadata:
     eslint-plugin-react-hooks: 4.5.0
     fs-extra: 10.1.0
     gatsby: 4.14.1
-    gatsby-image: 3.11.0
     gatsby-plugin-image: 2.14.1
     gatsby-plugin-mdx: 3.14.0
     gatsby-plugin-sharp: 4.14.1
@@ -16320,13 +16308,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-fit-images@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "object-fit-images@npm:3.2.4"
-  checksum: a1adab3e09fdc4f5addbd0895eeffbaa5018ffabb95382cd1bbf86bb813d21ca575ec4be4fdc5470fdaa25579a781748fd0b37308156d3605004256497d2d264
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
  * https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide/