### PR TITLE
chore(deps): disable updates for netlify serverless functions

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,5 +3,12 @@
   "ignorePresets": [":prHourlyLimit2"],
   "enabledManagers": ["npm"],
   "branchPrefix": "dependencies/",
-  "commitMessagePrefix": "chore(deps): "
+  "commitMessagePrefix": "chore(deps): ",
+  "packageRules": [
+    {
+      "groupName": "netlify functions dependencies",
+      "matchPackagePatterns": ["^puppeteer", "chrome-aws-lambda"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
  * puppeteer and chrome-aws-lambda must be the same version to work
    properly
  * chrome-aws-lambda is now locked on version 10 but puppeteer is 14