### PR TITLE
feat(mdx): add Gallery component with masonry layout

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -8,3 +8,15 @@ export function wrapPageElement({ element, props }) {
     <Layout {...props}>{element}</Layout>
   );
 }
+
+export function onClientEntry() {
+  const setScrollbarWidth = () => {
+    const width = window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.style.setProperty(
+      '--scrollbar-width',
+      `${width}px`,
+    );
+  };
+  setScrollbarWidth();
+  window.addEventListener('resize', setScrollbarWidth);
+}

--- a/src/components/mdx/Gallery/Gallery.module.scss
+++ b/src/components/mdx/Gallery/Gallery.module.scss
@@ -1,0 +1,87 @@
+.Gallery {
+  margin-top: calc(2 * (1.68 * (10px + 0.2vw) + 0.2vw));
+  margin-bottom: calc(2 * (1.68 * (10px + 0.2vw) + 0.2vw));
+  margin-left: calc(
+    50% - 50vw + var(--borderSize, 20px) + var(--scrollbar-width, 0px) / 2
+  );
+  margin-right: calc(
+    50% - 50vw + var(--borderSize, 20px) + var(--scrollbar-width, 0px) / 2
+  );
+  padding: calc(1 * (1.68 * (18px + 0.2vw) + 0.2vw)) 2.4rem;
+  background: #002b36;
+
+  @media only screen and (min-width: 600px) {
+    clip-path: polygon(
+      0 calc(0% + 15px),
+      100% 0,
+      100% calc(100% - 15px),
+      0% 100%
+    );
+  }
+}
+
+.GalleryMobileList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  figcaption {
+    display: none;
+  }
+
+  :global(.gatsby-resp-image-wrapper) {
+    max-width: none !important;
+    margin: 0 !important;
+  }
+
+  @media only screen and (min-width: 600px) {
+    display: none;
+  }
+}
+
+.GalleryGrid {
+  display: none;
+
+  @media only screen and (min-width: 600px) {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+}
+
+.GalleryColumn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  figcaption {
+    display: none;
+  }
+
+  :global(.gatsby-resp-image-wrapper) {
+    max-width: none !important;
+    margin: 0 !important;
+  }
+}
+
+// Distribute the height gap evenly across all images in shorter columns (desktop only)
+@media only screen and (min-width: 600px) {
+  .GalleryColumnShort > * {
+    flex: 1;
+
+    :global(.gatsby-resp-image-wrapper) {
+      height: 100% !important;
+    }
+
+    :global(.gatsby-resp-image-background-image) {
+      padding-bottom: 0 !important;
+      height: 100% !important;
+    }
+
+    :global(.gatsby-resp-image-image) {
+      object-fit: cover;
+      height: 100%;
+    }
+  }
+}

--- a/src/components/mdx/Gallery/Gallery.tsx
+++ b/src/components/mdx/Gallery/Gallery.tsx
@@ -1,0 +1,85 @@
+import React, {
+  type ReactNode,
+  Children,
+  isValidElement,
+  type ReactElement,
+} from 'react';
+import * as styles from './Gallery.module.scss';
+
+const COLUMNS = 4;
+const DEFAULT_RATIO = 0.67;
+
+function extractHeightRatio(node: ReactNode): number | null {
+  if (!isValidElement(node)) {
+    return null;
+  }
+
+  const element = node as ReactElement<any>;
+
+  if (
+    typeof element.props?.className === 'string' &&
+    element.props.className.includes('gatsby-resp-image-background-image') &&
+    element.props?.style
+  ) {
+    const paddingBottom =
+      element.props.style.paddingBottom ??
+      element.props.style['padding-bottom'];
+    if (paddingBottom) {
+      return parseFloat(paddingBottom) / 100;
+    }
+  }
+
+  const children = Children.toArray(element.props?.children ?? []);
+  for (const child of children) {
+    const result = extractHeightRatio(child);
+    if (result !== null) return result;
+  }
+
+  return null;
+}
+
+const Gallery = ({ children }: { children: ReactNode }) => {
+  const items = Children.toArray(children).filter(
+    (item) => typeof item !== 'string',
+  );
+
+  const columns: ReactNode[][] = Array.from({ length: COLUMNS }, () => []);
+  const heights = Array(COLUMNS).fill(0);
+
+  items.forEach((item) => {
+    const ratio = extractHeightRatio(item) ?? DEFAULT_RATIO;
+    const shortest = heights.indexOf(Math.min(...heights));
+    columns[shortest].push(item);
+    heights[shortest] += ratio;
+  });
+
+  const maxHeight = Math.max(...heights);
+  const activeColumns = columns
+    .map((column, i) => ({ column, height: heights[i] }))
+    .filter(({ column }) => column.length > 0);
+
+  return (
+    <div className={styles.Gallery} data-testid="gallery">
+      <div className={styles.GalleryMobileList}>{items}</div>
+      <div className={styles.GalleryGrid} data-testid="gallery-grid">
+        {activeColumns.map(({ column, height }, index) => (
+          <div
+            key={`gallery-column-${column}-${index}`}
+            data-testid={
+              height < maxHeight ? 'gallery-column-short' : 'gallery-column'
+            }
+            className={
+              height < maxHeight
+                ? `${styles.GalleryColumn} ${styles.GalleryColumnShort}`
+                : styles.GalleryColumn
+            }
+          >
+            {column}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Gallery;

--- a/src/components/mdx/Gallery/__tests__/Gallery.test.tsx
+++ b/src/components/mdx/Gallery/__tests__/Gallery.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import Gallery from '../Gallery';
+
+// Mirrors the HTML structure gatsby-remark-images generates, including the
+// nested span that carries padding-bottom as the aspect-ratio hint.
+function makeImage(paddingBottom: string, key: string) {
+  return (
+    <p key={key}>
+      <span className="gatsby-resp-image-wrapper">
+        <span
+          className="gatsby-resp-image-background-image"
+          style={{ paddingBottom }}
+        />
+        <img className="gatsby-resp-image-image" alt={key} src="test.jpg" />
+      </span>
+    </p>
+  );
+}
+
+function makeImages(count: number, paddingBottom = '66.67%') {
+  return Array.from({ length: count }, (_, index) =>
+    makeImage(paddingBottom, `img${index}`),
+  );
+}
+
+describe('Gallery', () => {
+  it('renders images', () => {
+    render(<Gallery>{makeImage('66.67%', 'img0')}</Gallery>);
+    // Image renders in both the mobile list and the desktop grid
+    expect(screen.getAllByRole('img', { name: 'img0' })).toHaveLength(2);
+  });
+
+  it('renders only non-empty columns', () => {
+    render(<Gallery>{makeImages(6)}</Gallery>);
+    // 6 images distributed into 4 columns — all 4 receive at least one item
+    expect(screen.getByTestId('gallery-grid').children).toHaveLength(4);
+  });
+
+  it('renders fewer columns when items are fewer than COLUMNS', () => {
+    render(<Gallery>{makeImages(3)}</Gallery>);
+    expect(screen.getByTestId('gallery-grid').children).toHaveLength(3);
+  });
+
+  it('filters out string children', () => {
+    render(
+      <Gallery>
+        {'\n'}
+        {makeImage('66.67%', 'a')}
+        {'\n'}
+        {makeImage('66.67%', 'b')}
+      </Gallery>,
+    );
+    // Scope to the grid to avoid counting the mobile-list duplicate
+    expect(
+      within(screen.getByTestId('gallery-grid')).getAllByRole('img'),
+    ).toHaveLength(2);
+  });
+
+  it('renders all images — none are dropped', () => {
+    render(<Gallery>{makeImages(14)}</Gallery>);
+    // Scope to the grid to avoid counting the mobile-list duplicate
+    expect(
+      within(screen.getByTestId('gallery-grid')).getAllByRole('img'),
+    ).toHaveLength(14);
+  });
+
+  it('marks shorter columns with gallery-column-short testid', () => {
+    // 14 uniform images → 4+4+3+3 distribution, two columns end up shorter in height
+    render(<Gallery>{makeImages(14, '133.333%')}</Gallery>);
+    expect(screen.getAllByTestId('gallery-column-short')).toHaveLength(2);
+  });
+
+  it('marks no column as short when items divide evenly across 4 columns', () => {
+    render(<Gallery>{makeImages(8)}</Gallery>);
+    expect(screen.queryAllByTestId('gallery-column-short')).toHaveLength(0);
+    expect(screen.getAllByTestId('gallery-column')).toHaveLength(4);
+  });
+
+  it('renders empty gallery without crashing', () => {
+    render(<Gallery>{''}</Gallery>);
+    expect(screen.getByTestId('gallery-grid')).toBeInTheDocument();
+  });
+
+  it('uses shortest-column: a tall image limits its column item count', () => {
+    // One very tall image (200%) followed by 4 short ones (50%).
+    // The tall image fills col0; the short images prefer the remaining shorter columns,
+    // so col0 ends up with fewer items than at least one other column.
+    const kids = [
+      makeImage('200%', 'tall'),
+      makeImage('50%', 'a'),
+      makeImage('50%', 'b'),
+      makeImage('50%', 'c'),
+      makeImage('50%', 'd'),
+    ];
+    render(<Gallery>{kids}</Gallery>);
+    const grid = screen.getByTestId('gallery-grid');
+    const counts = [...grid.children].map(
+      (col) => within(col as HTMLElement).getAllByRole('img').length,
+    );
+    expect(Math.max(...counts)).toBeGreaterThan(Math.min(...counts));
+  });
+
+  it('falls back to default ratio when no padding-bottom is found', () => {
+    // Plain divs have no gatsby structure; extractHeightRatio returns null
+    // and DEFAULT_RATIO is used for distribution.
+    render(
+      <Gallery>
+        <div key="a">no ratio</div>
+        <div key="b">no ratio</div>
+        <div key="c">no ratio</div>
+      </Gallery>,
+    );
+    // 3 items → 3 non-empty columns
+    expect(screen.getByTestId('gallery-grid').children).toHaveLength(3);
+  });
+});

--- a/src/components/mdx/Gallery/index.ts
+++ b/src/components/mdx/Gallery/index.ts
@@ -1,0 +1,1 @@
+export { default as Gallery } from './Gallery';

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Code from './Code';
+import { Gallery } from './Gallery';
 import H from './Headings';
 import Pre from './Pre';
 import T from './Tags';
@@ -19,6 +20,7 @@ export default {
   // p: props => <Text {...props} />,
   code: (props) => <Code {...props} />,
   pre: (props) => <Pre {...props} />,
+  Gallery: (props) => <Gallery {...props} />,
   // table: Table,
   // blockquote: Blockquote,
   // TODO add `a`


### PR DESCRIPTION
## Description

MDX posts had no way to embed a compact photo gallery — images dropped inline as individual blocks with no layout control. This adds a `<Gallery>` MDX component backed by a shortest-column masonry algorithm: it reads each image's aspect ratio from Gatsby's embedded `padding-bottom` style (no DOM access, SSR-safe) and distributes photos to keep column heights as equal as possible.

On desktop (≥ 600 px) the gallery renders 4 columns. When column counts don't divide evenly, the height gap is spread across all images in shorter columns via `flex: 1` — a ~25 % uniform crop rather than one image doubled in height. On mobile (< 600 px) columns stack into a single full-width feed with images at natural aspect ratio.

`onClientEntry` in `gatsby-browser.tsx` tracks scrollbar width as a CSS custom property so the full-bleed gallery margins don't shift when a scrollbar appears.

### Additional context

Aspect ratios are extracted by traversing the React element tree to find Gatsby's `.gatsby-resp-image-background-image` span and reading its inline `padding-bottom` (e.g. `133.33%` → height ratio `1.33`). This avoids any `useEffect`/DOM dependency and works identically at build time and in the browser.